### PR TITLE
Add support for the new URI format in Windows connector

### DIFF
--- a/windows/EFwebConnector.bat
+++ b/windows/EFwebConnector.bat
@@ -68,11 +68,11 @@ REM GOTO SKIP_PAUSE
         SET "SERVER_NAME=!SERVER_NAME:%%3C=^<!"
         SET "SERVER_NAME=!SERVER_NAME:%%7C=^|!"
         ECHO [95m URI string: %ARGUMENTS%
-        ECHO 
+        ECHO.
         ECHO [92m Joining %SERVER_NAME%  Map:   %MAP_NAME% [0m
-        ECHO 
+        ECHO.
         ECHO [93m PRESS ANY KEY TO JOIN
-        ECHO 
+        ECHO.
         PAUSE
     REM ----------------------------------------------------------------------------------------------------------------------------------------
 

--- a/windows/EFwebConnector.bat
+++ b/windows/EFwebConnector.bat
@@ -1,4 +1,6 @@
 @ECHO OFF
+SETLOCAL ENABLEDELAYEDEXPANSION
+
 REM     This Script will allow you to connect to Elite Force servers by clicking on the 'Join' buttons on https://efservers.com
 REM ----------------------------------------------------------------------------------------------------------------------------------------
 REM     This code decides which game EXE to use (%EF_EXE%), order of preference is cmod, lilium, ioef, fallback to stvoyHM.exe
@@ -47,8 +49,17 @@ REM     Then the information for joining the chosen server is extracted from the
 REM     and put in a format that the Elite Force executable can understand
 
 SET ARGUMENTS=%1
-SET "ARGUMENTS=%ARGUMENTS:stvef:=%"
-FOR /f "tokens=1,2,3,4 delims=; " %%a IN ("%ARGUMENTS%") DO SET "SERVER_IP=%%a"&SET "SERVER_PORT=%%b"&SET "SERVER_NAME=%%c"&SET "MAP_NAME=%%d"
+SET ARGUMENTS=%ARGUMENTS:stvef:=%
+SET ARGUMENTS=%ARGUMENTS:"=%
+IF "%ARGUMENTS:~0,2%"=="//" SET ARGUMENTS=%ARGUMENTS:~2%
+IF "%ARGUMENTS:~0,8%"=="connect/" (
+  REM This is the new URI format from https://github.com/ioquake/ioq3/commit/31c6d2f9d502868970ccbe62d7cef36206cbc8b1
+  SET HOST=%ARGUMENTS:~8%
+  GOTO SKIP_PAUSE
+) ELSE (
+  FOR /f "tokens=1,2,3,4 delims=; " %%a IN ("%ARGUMENTS%") DO SET "SERVER_IP=%%a"&SET "SERVER_PORT=%%b"&SET "SERVER_NAME=%%c"&SET "MAP_NAME=%%d"
+  SET HOST=!SERVER_IP!:!SERVER_PORT!
+)
 
     REM ----------------------------------------------------------------------------------------------------------------------------------------
     REM     THIS BLOCK IS OPTIONAL - Pauses the script before launching the game, while displaying the
@@ -60,7 +71,6 @@ REM GOTO SKIP_PAUSE
 
         GOTO SHOW_LOGO
         :PAUSE_BEFORE_LAUNCH
-        SETLOCAL ENABLEDELAYEDEXPANSION
         SET "SERVER_NAME=!SERVER_NAME:%%20= !"
         SET "SERVER_NAME=!SERVER_NAME:%%5C=\!"
         SET "SERVER_NAME=!SERVER_NAME:%%7B={!"
@@ -79,7 +89,7 @@ REM GOTO SKIP_PAUSE
 :SKIP_PAUSE
 REM *****************************************************************************************************************************************
 REM     This starts EF with the CONNECT command with the selected server IP and Port
-    START "" /D "%~dp0 " "%ELITE_FORCE_EXECUTABLE%" +set logfile 2 +CONNECT %SERVER_IP%:%SERVER_PORT%
+    START "" /D "%~dp0 " "%ELITE_FORCE_EXECUTABLE%" +set logfile 2 +CONNECT %HOST%
 EXIT 0
 REM *****************************************************************************************************************************************
 
@@ -122,7 +132,7 @@ GOTO PAUSE_BEFORE_LAUNCH
 :::[93m
 :::        .^.
 ::: .-----'   `-----.   Star Trek Voyager: Elite Force
-::: | [##'     `##] |   Web-connector Script v0.9
+::: | [##'     `##] |   Web-connector Script v1.0
 ::: `---'   __  `---'   From efservers.com
 :::    | .-'  `. |      Join a game directly from
 :::    |'       `|      The website/webapp!

--- a/windows/EFwebProtocolRegister.bat
+++ b/windows/EFwebProtocolRegister.bat
@@ -1,0 +1,79 @@
+@ECHO OFF
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+ECHO.
+ECHO [93m:::
+ECHO :::        .^^.
+ECHO ::: .-----'   `-----.   Star Trek Voyager: Elite Force
+ECHO ::: ^| [##'     `##] ^|   Web-connector Script v1.0
+ECHO ::: `---'   __  `---'   From efservers.com
+ECHO :::    ^| .-'  `. ^|      Join a game directly from
+ECHO :::    ^|'       `^|      The website/webapp!
+ECHO :::
+ECHO ::: Note: This file only works with game clients that will probably
+ECHO :::       not be released until 2024 (or maybe even later)
+ECHO :::       Use EFwebConnector.bat if this one doesn't work.
+ECHO ::: [0m
+ECHO.
+
+SET ELITE_FORCE_EXECUTABLE=
+
+SET "EF_EXE_0=%~dp0stvoyhm.exe"
+SET "EF_EXE_1=%~dp0iostvoyHM.x86.exe"
+SET "EF_EXE_2=%~dp0iostvoyHM.x86_64.exe"
+SET "EF_EXE_3=%~dp0liliumvoyhm.x86.exe"
+SET "EF_EXE_4=%~dp0liliumvoyhm.x86_64.exe"
+SET "EF_EXE_5=%~dp0tulipvoyhm.x86_64.exe"
+SET "EF_EXE_6=%~dp0cMod-stvoyHM.exe"
+SET "EF_EXE_7=%~dp0ioEF-cMod.x86.exe"
+SET "EF_EXE_8=%~dp0ioEF-cMod.x86_64.exe"
+
+IF EXIST "%EF_EXE_0%" (SET "ELITE_FORCE_EXECUTABLE=%EF_EXE_0%")
+IF EXIST "%EF_EXE_1%" (SET "ELITE_FORCE_EXECUTABLE=%EF_EXE_1%")
+IF EXIST "%EF_EXE_2%" (SET "ELITE_FORCE_EXECUTABLE=%EF_EXE_2%")
+IF EXIST "%EF_EXE_3%" (SET "ELITE_FORCE_EXECUTABLE=%EF_EXE_3%")
+IF EXIST "%EF_EXE_4%" (SET "ELITE_FORCE_EXECUTABLE=%EF_EXE_4%")
+IF EXIST "%EF_EXE_5%" (SET "ELITE_FORCE_EXECUTABLE=%EF_EXE_5%")
+IF EXIST "%EF_EXE_6%" (SET "ELITE_FORCE_EXECUTABLE=%EF_EXE_6%")
+IF EXIST "%EF_EXE_7%" (SET "ELITE_FORCE_EXECUTABLE=%EF_EXE_7%")
+IF EXIST "%EF_EXE_8%" (SET "ELITE_FORCE_EXECUTABLE=%EF_EXE_8%")
+
+IF NOT EXIST "%ELITE_FORCE_EXECUTABLE%" (
+  ECHO Warning: Could not find elite force executable.
+  ECHO If this file was not placed in your elite force directory
+  ECHO then please close this window and move the file.
+  ECHO.
+  ECHO You can download the game from the LINKS page at https://efservers.com
+  ECHO.
+  ECHO If your game client executable is not recognized then enter the
+  ECHO executable file name here, including ".exe".
+  ECHO.
+  SET /P EF_EXE="Enter executable filename: "
+  ECHO.
+  SET ELITE_FORCE_EXECUTABLE=%~dp0!EF_EXE!
+  IF NOT EXIST "!ELITE_FORCE_EXECUTABLE!" (
+    ECHO Still can't find the file. Sorry.
+    ECHO %ELITE_FORCE_EXECUTABLE%
+    ECHO.
+    PAUSE
+    EXIT /B 1
+  )
+)
+
+REG ADD "HKCU\Software\Classes\stvef" /v "CustomUrlApplication" /t REG_SZ /d "%ELITE_FORCE_EXECUTABLE%" /F
+REG ADD "HKCU\Software\Classes\stvef" /v "CustomUrlArguments"   /t REG_SZ /d "\"%%1\"" /F
+REG ADD "HKCU\Software\Classes\stvef" /v "URL Protocol"         /t REG_SZ /d "" /F
+REG ADD "HKCU\Software\Classes\stvef\DefaultIcon"               /t REG_SZ /d "%ELITE_FORCE_EXECUTABLE%,0" /F
+REG ADD "HKCU\Software\Classes\stvef\shell\open\command"        /t REG_SZ /d "\"%ELITE_FORCE_EXECUTABLE%\" +set logfile 2 --uri \"%%1\"" /F
+
+ECHO.
+ECHO [93m:::
+ECHO ::: If you saw five successful operations above then that
+ECHO ::: means that the URI protocol was registered successfully.
+ECHO :::
+ECHO ::: Now open https://efservers.com and join a server.
+ECHO ::: See you out there, commander^^!
+ECHO ::: [0m
+ECHO.
+
+PAUSE

--- a/windows/EFwebProtocolRegister.bat
+++ b/windows/EFwebProtocolRegister.bat
@@ -68,7 +68,7 @@ REG ADD "HKCU\Software\Classes\stvef\shell\open\command"        /t REG_SZ /d "\"
 
 ECHO.
 ECHO [93m:::
-ECHO ::: If you saw five successful operations above then that
+ECHO ::: If you see five successful operations above then that
 ECHO ::: means that the URI protocol was registered successfully.
 ECHO :::
 ECHO ::: Now open https://efservers.com and join a server.


### PR DESCRIPTION
This updates the Windows connector to support both [the new](https://github.com/ioquake/ioq3/commit/31c6d2f9d502868970ccbe62d7cef36206cbc8b1) and the old URI format. It also adds a second bat file which registers directly with the game client, but this script should probably not be distributed for a year or two, until updated EF game clients start coming out. I compiled my own Lilium Voyager with the patch cherry-picked to test this properly.

GitHub doesn't support arbitrary protocols in links, so I'm using tinyurl to redirect to the `stvef` protocol. All of these links should now work.

<p><a href="https://tinyurl.com/58d3ktc5">stvef:connect/74.91.116.226:2796</a></p>

<p><a href="https://tinyurl.com/yc74j25v">stvef://connect/74.91.116.226:2796</a></p>

<p><a href="https://tinyurl.com/3sddwvcx">stvef:74.91.116.226;27961;Specialties;ctf_voy_x_quadrant;0;</a></p>

<p><a href="https://tinyurl.com/ywjrzr9d">stvef://74.91.116.226;27961;Specialties;ctf_voy_x_quadrant;0;</a></p>

The new URI format automatically skips the server info screen, since there's no information to display there (but we could technically add arbitrary data at the end, e.g. `?server_name=Specialties;map=ctf_voy_x_quadrant`).

P.S. I was having some weird issue with the server info screen. It is somehow causing the game client to not show up even though the screen resolution changes and the game audio playing. I have to open the task manager and kill it. No idea what is going on but I can reproduce it consistently. Disabling the server info screen fixes it.

The new script produces this output:

![Screenshot 2023-05-01 215224](https://user-images.githubusercontent.com/1991151/235584985-2d56fd5a-d943-44c9-ba78-c2e7faf133d1.png)

